### PR TITLE
Handle process completion without poll in CommandExecutor

### DIFF
--- a/lib/CommandExecutor.py
+++ b/lib/CommandExecutor.py
@@ -176,10 +176,10 @@ class CommandExecutor:
 
     def execute_with_timeout(self, command: str, timeout: int = COMMAND_TIMEOUT) -> CommandResult:
         """Execute a command with a specific timeout"""
+        global COMMAND_TIMEOUT
         original_timeout = COMMAND_TIMEOUT
         try:
             # Temporarily change timeout
-            global COMMAND_TIMEOUT
             COMMAND_TIMEOUT = timeout
             return self.execute_command(command)
         finally:
@@ -253,7 +253,7 @@ class CommandExecutor:
                     killed = True
                     break
                 await asyncio.sleep(0.1)
-                await process.poll()
+            await process.wait()
             # Wait for output reading to finish
             await stdout_task
             await stderr_task


### PR DESCRIPTION
## Summary
- remove erroneous `await process.poll()` in async executor loop
- wait on subprocess with `await process.wait()` and rely on returncode
- fix `execute_with_timeout` global declaration order

## Testing
- `python -m pytest`
- `python - <<'PY' ... PY`

------
https://chatgpt.com/codex/tasks/task_e_689bf9a52eb48327a517c7b8b02e8e17