### PR TITLE
Centralize debug printing via logging utility

### DIFF
--- a/lib/Agents.py
+++ b/lib/Agents.py
@@ -12,14 +12,7 @@ import pickle
 import hashlib
 from collections import defaultdict
 from lib.config import Config
-
-# Load environment variables
-DEBUG = os.getenv('DEBUG', '0') == '1'
-
-def debug_print(*args, **kwargs):
-    """Print debug messages only if DEBUG is enabled"""
-    if DEBUG:
-        print("[DEBUG]", *args, **kwargs)
+from lib.logging_utils import debug_print
 
 class AgentType(Enum):
     """Types of agents available"""

--- a/lib/App.py
+++ b/lib/App.py
@@ -9,15 +9,10 @@ import os
 import asyncio
 from lib.Exporter import export_alpaca_data
 from lib.config import Config
+from lib.logging_utils import debug_print
 
 # Load environment variables
-DEBUG = os.getenv('DEBUG', '0') == '1'
 COMMAND_TIMEOUT = int(os.getenv('COMMAND_TIMEOUT', '300'))  # 5 minutes default timeout
-
-def debug_print(*args, **kwargs):
-    """Print debug messages only if DEBUG is enabled"""
-    if DEBUG:
-        print("[DEBUG]", *args, **kwargs)
 
 class App:
     def __init__(self):

--- a/lib/Chat.py
+++ b/lib/Chat.py
@@ -5,6 +5,7 @@ from lib.Tools import Tools, CommandResult
 from typing import Tuple, List, Dict, Optional
 from .Model import Model
 from .Agents import AgentManager, AgentType, AgentTask
+from lib.logging_utils import debug_print
 import re
 
 class Chat:

--- a/lib/CommandExecutor.py
+++ b/lib/CommandExecutor.py
@@ -5,16 +5,11 @@ import psutil
 import time
 from typing import Optional, Tuple
 from dataclasses import dataclass
+from lib.logging_utils import debug_print
 
 # Load environment variables
-DEBUG = os.getenv('DEBUG', '0') == '1'
 COMMAND_TIMEOUT = int(os.getenv('COMMAND_TIMEOUT', '300'))  # 5 minutes default timeout
 MEMORY_THRESHOLD = float(os.getenv('MEMORY_THRESHOLD', '0.8'))  # 80% memory threshold
-
-def debug_print(*args, **kwargs):
-    """Print debug messages only if DEBUG is enabled"""
-    if DEBUG:
-        print("[DEBUG]", *args, **kwargs)
 
 @dataclass
 class CommandResult:
@@ -176,10 +171,10 @@ class CommandExecutor:
 
     def execute_with_timeout(self, command: str, timeout: int = COMMAND_TIMEOUT) -> CommandResult:
         """Execute a command with a specific timeout"""
+        global COMMAND_TIMEOUT
         original_timeout = COMMAND_TIMEOUT
         try:
             # Temporarily change timeout
-            global COMMAND_TIMEOUT
             COMMAND_TIMEOUT = timeout
             return self.execute_command(command)
         finally:

--- a/lib/Model.py
+++ b/lib/Model.py
@@ -11,14 +11,10 @@ from llama_cpp import Llama
 from llama_cpp.llama_grammar import LlamaGrammar
 from .Tools import Tools, CommandResult
 from lib.config import Config
+from lib.logging_utils import debug_print
 
 # Load environment variables
 DEBUG = os.getenv('DEBUG', '0') == '1'
-
-def debug_print(*args, **kwargs):
-    """Print debug messages only if DEBUG is enabled"""
-    if DEBUG:
-        print("[DEBUG]", *args, **kwargs)
 
 # Suppress warnings
 warnings.filterwarnings("ignore")

--- a/lib/RAG.py
+++ b/lib/RAG.py
@@ -11,14 +11,7 @@ from collections import defaultdict, Counter
 import networkx as nx
 import heapq
 from lib.config import Config
-
-# Load environment variables
-DEBUG = os.getenv('DEBUG', '0') == '1'
-
-def debug_print(*args, **kwargs):
-    """Print debug messages only if DEBUG is enabled"""
-    if DEBUG:
-        print("[DEBUG]", *args, **kwargs)
+from lib.logging_utils import debug_print
 
 # For embeddings and vector search
 try:

--- a/lib/Tools.py
+++ b/lib/Tools.py
@@ -10,6 +10,7 @@ from .WordlistManager import WordlistManager
 from .TargetParser import TargetParser
 from .ToolRegistry import ToolRegistry
 from lib.config import Config
+from lib.logging_utils import debug_print
 
 # Import RAG functionality
 try:
@@ -17,14 +18,6 @@ try:
     RAG_AVAILABLE = True
 except ImportError:
     RAG_AVAILABLE = False
-
-# Load environment variables
-DEBUG = os.getenv('DEBUG', '0') == '1'
-
-def debug_print(*args, **kwargs):
-    """Print debug messages only if DEBUG is enabled"""
-    if DEBUG:
-        print("[DEBUG]", *args, **kwargs)
 
 class Tools:
     def __init__(self, config: Config, concurrency_limit: int = 5):

--- a/lib/WordlistManager.py
+++ b/lib/WordlistManager.py
@@ -7,14 +7,10 @@ import heapq
 import aiohttp
 import asyncio
 from lib.config import Config
+from lib.logging_utils import debug_print
 
 # Load environment variables
 DEBUG = os.getenv('DEBUG', '0') == '1'
-
-def debug_print(*args, **kwargs):
-    """Print debug messages only if DEBUG is enabled"""
-    if DEBUG:
-        print("[DEBUG]", *args, **kwargs)
 
 class WordlistManager:
     """Manages wordlists for various security tools"""

--- a/lib/logging_utils.py
+++ b/lib/logging_utils.py
@@ -1,0 +1,13 @@
+import os
+import logging
+
+# Configure logging based on DEBUG environment variable
+if os.getenv("DEBUG") == "1":
+    logging.basicConfig(level=logging.DEBUG, format="[DEBUG] %(message)s")
+else:
+    logging.basicConfig(level=logging.INFO)
+
+def debug_print(*args, **kwargs):
+    """Log debug messages when the DEBUG environment variable is set."""
+    if os.getenv("DEBUG") == "1":
+        logging.debug(" ".join(str(a) for a in args))


### PR DESCRIPTION
## Summary
- Add `lib/logging_utils.py` providing a centralized `debug_print` that checks the `DEBUG` env var and uses Python's `logging` module
- Replace scattered `debug_print` definitions in modules like `App`, `Agents`, and `Tools` with imports from the new utility

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689bf9a6c9708327ab199060a85d4496