### PR TITLE
Ensure synchronous target input and non-blocking async prompts

### DIFF
--- a/lib/App.py
+++ b/lib/App.py
@@ -135,8 +135,8 @@ class App:
         debug_print(f"Extracted host: {target}")
         return target
     
-    async def get_target(self) -> str:
-        """Prompt user for target hostname/IP/URL and validate input (async for tool execution)"""
+    def get_target(self) -> str:
+        """Prompt user for target hostname/IP/URL and validate input"""
         while True:
             try:
                 target = input("\nEnter target hostname, IP address, or URL: ").strip()
@@ -152,7 +152,7 @@ class App:
                     # Use more conservative nmap settings
                     args = ['-sV', '-sC', '-p-', '--max-retries', '2', '--min-rate', '1000']
                     debug_print("Executing initial nmap scan...")
-                    result = await self.tools.async_execute_command("nmap", target, args)
+                    result = self.tools.execute_command("nmap", target, args)
                     if result.killed:
                         print(f"\nWarning: Initial scan was killed due to resource constraints.")
                         print("Continuing with limited information...")

--- a/lib/Chat.py
+++ b/lib/Chat.py
@@ -655,8 +655,10 @@ class Chat:
         commands = self._extract_commands(response)
         if commands:
             if self.interactive_mode:
-                # In interactive mode, ask user for approval
-                chosen_command = self._get_user_command_choice(commands)
+                # In interactive mode, ask user for approval without blocking the event loop
+                chosen_command = await asyncio.to_thread(
+                    self._get_user_command_choice, commands
+                )
                 if chosen_command:
                     await self._execute_commands([chosen_command], target)
             else:

--- a/lib/Tools.py
+++ b/lib/Tools.py
@@ -96,10 +96,19 @@ class Tools:
     async def async_execute_command(self, command: str, target: Optional[str] = None, args: Optional[List[str]] = None, tool_config: Optional[Dict] = None, timeout: int = None) -> CommandResult:
         """Asynchronously execute a command and return the result, with global concurrency limit"""
         async with self._semaphore:
-            result = await self.command_executor.async_execute_command(command, target, args, tool_config, timeout)
-            # Save command output if we have a target
+            result = await self.command_executor.async_execute_command(
+                command, target, args, tool_config, timeout
+            )
+            # Save command output if we have a target without blocking the event loop
             if target and result.output:
-                self._save_command_output(command, target, result.output, result.success, result.error)
+                await asyncio.to_thread(
+                    self._save_command_output,
+                    command,
+                    target,
+                    result.output,
+                    result.success,
+                    result.error,
+                )
             return result
     
     def initialize_scan_directory(self, target: str) -> str:

--- a/lib/WordlistManager.py
+++ b/lib/WordlistManager.py
@@ -141,7 +141,7 @@ class WordlistManager:
     
     async def async_download_wordlist(self, url: str, filename: str) -> bool:
         """Asynchronously download a wordlist from URL with resume support"""
-        self._maybe_warn_and_prompt_cleanup()
+        await asyncio.to_thread(self._maybe_warn_and_prompt_cleanup)
         filepath = os.path.join(self.wordlists_dir, filename)
         partfile = filepath + ".part"
         resume_byte_pos = 0


### PR DESCRIPTION
## Summary
- Make `App.get_target` synchronous and run initial scan via blocking `execute_command`
- Wrap blocking user prompts with `asyncio.to_thread` for non-blocking behavior in async contexts
- Updated Tools and WordlistManager to avoid event loop blocking during cleanup prompts

## Testing
- `python -m py_compile lib/App.py lib/Chat.py lib/Tools.py lib/WordlistManager.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689bf9ad3bf883278eb8250ce496ec75